### PR TITLE
Fix summing of losses

### DIFF
--- a/densecap/DenseCapModel.lua
+++ b/densecap/DenseCapModel.lua
@@ -452,10 +452,11 @@ function DenseCapModel:forward_backward(data)
     end_box_reg_loss=end_box_reg_loss,
     captioning_loss=captioning_loss,
   }
-  losses.total_loss = 0
+  local total_loss = 0
   for k, v in pairs(losses) do
-    losses.total_loss = losses.total_loss + v
+    total_loss = total_loss + v
   end
+  losses.total_loss = total_loss
 
   -- Run the model backward
   local grad_out = {}


### PR DESCRIPTION
`total_loss` was being added to itself at least once in the sum, now it
is excluded.

Example output from before the fix:

```
iter 0: mid_box_reg_loss: 0.001, captioning_loss: 50.864, end_objectness_loss: 0.087, mid_objectness_loss: 0.140, end_box_reg_loss: 0.003,  [total: 102.187]
```
And after:

```
iter 0: mid_box_reg_loss: 0.001, captioning_loss: 50.864, end_objectness_loss: 0.087, mid_objectness_loss: 0.140, end_box_reg_loss: 0.003,  [total: 51.095]
```

Fixes #32.